### PR TITLE
Fix alternative host and port usage

### DIFF
--- a/lib/mailtrap/sending/client.rb
+++ b/lib/mailtrap/sending/client.rb
@@ -30,7 +30,7 @@ module Mailtrap
       private
 
       def http_client
-        @http_client ||= Net::HTTP.new(API_HOST, API_PORT).tap { |client| client.use_ssl = true }
+        @http_client ||= Net::HTTP.new(api_host, api_port).tap { |client| client.use_ssl = true }
       end
 
       def post_request(path, body)

--- a/spec/fixtures/vcr_cassettes/Mailtrap_Sending_Client/_send/with_an_alternative_host/sending_is_successful.yml
+++ b/spec/fixtures/vcr_cassettes/Mailtrap_Sending_Client/_send/with_an_alternative_host/sending_is_successful.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://alternative.host.mailtrap.io:8080/api/send
+    body:
+      encoding: UTF-8
+      string: '{"to":[{"email":"mailtrap@railsware.com"}],"from":{"email":"mailtrap@mailtrap.io","name":"Mailtrap
+        Test"},"cc":[],"bcc":[],"subject":"You are awesome!","text":"Congrats for
+        sending test email with Mailtrap!","attachments":[{"content":"aGVsbG8gd29ybGQ=","filename":"attachment.txt"}],"headers":{},"category":"Integration
+        Test","custom_variables":{}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 13 Oct 2022 22:08:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '71'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"message_ids":["867394cd-4b43-11ed-af38-0a58a9feac02"]}'
+  recorded_at: Thu, 13 Oct 2022 22:08:10 GMT
+recorded_with: VCR 6.1.0

--- a/spec/mailtrap/sending/client_spec.rb
+++ b/spec/mailtrap/sending/client_spec.rb
@@ -61,5 +61,15 @@ RSpec.describe Mailtrap::Sending::Client do
 
       it { expect { send }.to raise_error(ArgumentError, 'should be Mailtrap::Sending::Mail object') }
     end
+
+    context 'with an alternative host' do
+      let(:client) do
+        described_class.new(api_key: api_key, api_host: 'alternative.host.mailtrap.io', api_port: 8080)
+      end
+
+      it 'sending is successful' do
+        expect(send).to eq({ message_ids: ['867394cd-4b43-11ed-af38-0a58a9feac02'], success: true })
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation
Fix `host` and `port` usage

### Issue
API host and port were used not from params passed, but from constant. Thus, all requests were sent to the main production host.

### Changes
Updated params usage and added a test that these params are used.