### PR TITLE
Add mail 2.8 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,13 +14,17 @@ jobs:
           - '3.1.2'
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - name: Lint
-      run: bundle exec rubocop
-    - name: Test
-      run: bundle exec rspec
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Bundle
+        run: bundle install
+      - name: Appraisal install
+        run: bundle exec appraisal install
+
+      - name: Lint
+        run: bundle exec rubocop
+      - name: Build and test
+        run: bundle exec appraisal rspec

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /_yardoc/
 /coverage/
 /doc/
+/gemfiles/
 /pkg/
 /spec/reports/
 /tmp/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,8 @@ require: rubocop-rspec
 AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
+  Exclude:
+    - 'gemfiles/**/*'
 
 Layout/LineLength:
   Max: 120

--- a/Appraisals
+++ b/Appraisals
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+appraise 'mail-2.7' do
+  gem 'mail', '~> 2.7.0'
+end
+
+appraise 'mail-2.8' do
+  gem 'mail', '~> 2.8.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'appraisal'
 gem 'mail'
 gem 'net-smtp'
 gem 'rake', '~> 13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,10 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
     ast (2.4.2)
     crack (0.4.5)
       rexml
@@ -55,6 +59,7 @@ GEM
     rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    thor (1.2.1)
     unicode-display_width (2.1.0)
     vcr (6.1.0)
     webmock (3.14.0)
@@ -66,6 +71,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  appraisal
   mail
   mailtrap!
   net-smtp

--- a/lib/mailtrap/sending/convert.rb
+++ b/lib/mailtrap/sending/convert.rb
@@ -6,12 +6,12 @@ module Mailtrap
   module Sending
     module Convert
       class << self
-        def from_message(message) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def from_message(message) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
           Mailtrap::Sending::Mail.new(
-            from: prepare_address(message['from']&.address_list&.addresses&.first),
-            to: prepare_addresses(message['to']&.address_list&.addresses),
-            cc: prepare_addresses(message['cc']&.address_list&.addresses),
-            bcc: prepare_addresses(message['bcc']&.address_list&.addresses),
+            from: prepare_address(address_list(message['from'])&.addresses&.first),
+            to: prepare_addresses(address_list(message['to'])&.addresses),
+            cc: prepare_addresses(address_list(message['cc'])&.addresses),
+            bcc: prepare_addresses(address_list(message['bcc'])&.addresses),
             subject: message.subject,
             text: prepare_text_part(message),
             html: prepare_html_part(message),
@@ -34,6 +34,10 @@ module Mailtrap
           customvariables
           contenttype
         ].freeze
+
+        def address_list(header)
+          header.respond_to?(:element) ? header.element : header&.address_list
+        end
 
         def prepare_addresses(addresses)
           Array(addresses).map { |address| prepare_address(address) }
@@ -61,7 +65,7 @@ module Mailtrap
               type: attachment.mime_type,
               filename: attachment.filename,
               disposition: attachment.header[:content_disposition]&.disposition_type,
-              content_id: attachment.header[:content_id]&.field&.content_id
+              content_id: attachment&.cid
             }.compact
           end
         end


### PR DESCRIPTION
## Motivation
`address_list` method was removed from `mail` gem 2.8+.
Related links:
- https://github.com/mikel/mail/issues/1521
- https://github.com/rails/rails/pull/46643/

## Changes
- Add `mail` 2.8+ support
- Test gem with multiple `mail` gem versions
