### PR TITLE
Reverse order in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,3 @@
-## [1.0.0] - 2022-06-14
-
-- Initial release
-
-## [1.0.1] - 2022-06-20
-
-- Update packed files list
-
-
-## [1.1.0] - 2022-07-22
-
-- Add ActionMailer support
-
-## [1.1.1] - 2022-10-14
-
-- Fix custom port and host usage
-
 ## [1.2.0] - 2023-01-27
 
 - Breaking changes:
@@ -22,3 +5,19 @@
   - move `Mailtrap::Sending::Convert` to `Mailtrap::Mail`
 - Add mail gem 2.8 support
 - Add email template support
+
+## [1.1.1] - 2022-10-14
+
+- Fix custom port and host usage
+
+## [1.1.0] - 2022-07-22
+
+- Add ActionMailer support
+
+## [1.0.1] - 2022-06-20
+
+- Update packed files list
+
+## [1.0.0] - 2022-06-14
+
+- Initial release


### PR DESCRIPTION
## Motivation

Everywhere I looked on GitHub, changelogs are written in a way that new versions are prepended, not appended. Even in our own mailtrap-nodejs https://github.com/railsware/mailtrap-nodejs/blob/main/CHANGELOG.md.

## Changes

- Reverse order in CHANGELOG.md

## How to test

Not needed.

## Images and GIFs

None.