### PR TITLE
Improved error handling

### DIFF
--- a/lib/mailtrap/sending.rb
+++ b/lib/mailtrap/sending.rb
@@ -17,6 +17,21 @@ module Mailtrap
       end
     end
 
+    # AuthorizationError is raised when invalid token is used.
     class AuthorizationError < Error; end
+
+    # MailSizeError is raised when mail is too large.
+    class MailSizeError < Error; end
+
+    # RateLimitError is raised when client performing too many requests.
+    class RateLimitError < Error; end
+
+    # RejectionError is raised when server refuses to process the request. Use
+    # error message to debug the problem.
+    #
+    # *Some* possible reasons:
+    #   * Account is banned
+    #   * Domain is not verified
+    class RejectionError < Error; end
   end
 end

--- a/lib/mailtrap/sending/client.rb
+++ b/lib/mailtrap/sending/client.rb
@@ -44,15 +44,25 @@ module Mailtrap
       end
 
       def handle_response(response)
-        case response.code
-        when '200'
+        case response
+        when Net::HTTPOK
           json_response(response.body)
-        when '400'
+        when Net::HTTPBadRequest
           raise Mailtrap::Sending::Error, json_response(response.body)[:errors]
-        when '401'
+        when Net::HTTPUnauthorized
           raise Mailtrap::Sending::AuthorizationError, json_response(response.body)[:errors]
-        else
+        when Net::HTTPForbidden
+          raise Mailtrap::Sending::RejectionError, json_response(response.body)[:errors]
+        when Net::HTTPPayloadTooLarge
+          raise Mailtrap::Sending::MailSizeError, ['message too large']
+        when Net::HTTPTooManyRequests
+          raise Mailtrap::Sending::RateLimitError, ['too many requests']
+        when Net::HTTPClientError
+          raise Mailtrap::Sending::Error, ['client error']
+        when Net::HTTPServerError
           raise Mailtrap::Sending::Error, ['server error']
+        else
+          raise Mailtrap::Sending::Error, ["unexpected status code=#{response.code}"]
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require 'mail'
 require 'mailtrap'
 require 'rspec/its'
+require 'webmock/rspec'
 require 'vcr'
 
 VCR.configure do |config|


### PR DESCRIPTION
## Motivation

Mailtrap sending client used to raise `server error` on 403.

## Changes

- Improved error handling

## How to test

- [ ] Send an email when domain is not verified. Proper error should be raised.