### PR TITLE
improved error handling

### DIFF
--- a/lib/mailtrap/sending.rb
+++ b/lib/mailtrap/sending.rb
@@ -17,6 +17,21 @@ module Mailtrap
       end
     end
 
+    # AuthorizationError is raised when invalid token is used.
     class AuthorizationError < Error; end
+
+    # MailSizeError is raised when mail is too large.
+    class MailSizeError < Error; end
+
+    # RateLimitError is raised when client performing too many requests.
+    class RateLimitError < Error; end
+
+    # RejectionError is raised when server refuses to process the request. Use
+    # error message to debug the problem.
+    #
+    # *Some* possible reasons:
+    #   * Account is banned
+    #   * Domain is not verified
+    class RejectionError < Error; end
   end
 end

--- a/spec/mailtrap/sending/client_spec.rb
+++ b/spec/mailtrap/sending/client_spec.rb
@@ -108,4 +108,71 @@ RSpec.describe Mailtrap::Sending::Client do
       end
     end
   end
+
+  describe 'errors' do
+    subject(:send_mail) { client.send(mail) }
+
+    let(:mail) do
+      Mailtrap::Mail::Base.new(
+        from: { email: 'from@example.com' },
+        to: [{ email: 'to@example.com' }],
+        subject: 'Test',
+        text: 'Test'
+      )
+    end
+
+    def stub_api_send(status, body = nil)
+      stub = stub_request(:post, %r{/api/send}).to_return(status: status, body: body)
+      yield
+      expect(stub).to have_been_requested
+    end
+
+    it 'handles 400' do
+      stub_api_send 400, '{"errors":["error"]}' do
+        expect { send_mail }.to raise_error(Mailtrap::Sending::Error)
+      end
+    end
+
+    it 'handles 401' do
+      stub_api_send 401, '{"errors":["Unauthorized"]}' do
+        expect { send_mail }.to raise_error(Mailtrap::Sending::AuthorizationError)
+      end
+    end
+
+    it 'handles 403' do
+      stub_api_send 403, '{"errors":["Account is banned"]}' do
+        expect { send_mail }.to raise_error(Mailtrap::Sending::RejectionError)
+      end
+    end
+
+    it 'handles 413' do
+      stub_api_send 413 do
+        expect { send_mail }.to raise_error(Mailtrap::Sending::MailSizeError)
+      end
+    end
+
+    it 'handles 429' do
+      stub_api_send 429 do
+        expect { send_mail }.to raise_error(Mailtrap::Sending::RateLimitError)
+      end
+    end
+
+    it 'handles generic client errors' do
+      stub_api_send 418, '🫖' do
+        expect { send_mail }.to raise_error(Mailtrap::Sending::Error, 'client error')
+      end
+    end
+
+    it 'handles server errors' do
+      stub_api_send 504, '🫖' do
+        expect { send_mail }.to raise_error(Mailtrap::Sending::Error, 'server error')
+      end
+    end
+
+    it 'handles unexpected response status code' do
+      stub_api_send 307 do
+        expect { send_mail }.to raise_error(Mailtrap::Sending::Error, 'unexpected status code=307')
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require 'mail'
 require 'mailtrap'
 require 'rspec/its'
+require 'webmock/rspec'
 require 'vcr'
 
 VCR.configure do |config|


### PR DESCRIPTION
## Motivation

Mailtrap sending client used to raise `server error` on 403.


## Changes

- Improved error handling

## How to test

- [ ] Send an email when domain is not verified. Proper error should be raised.