### PR TITLE
Release version 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.1.0] - 2024-07-08
+
+- Fixed extraneous headers added by ActionMailer #21
+- Dropped Ruby 2.7 support and added test coverage for Ruby up to 3.3 #22
+
 ## [2.0.0] - 2024-03-20
 
 - Added arguments for `Mailtrap::Client`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mailtrap (2.0.0)
+    mailtrap (2.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/mailtrap/version.rb
+++ b/lib/mailtrap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mailtrap
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
## Motivation

Release new gem version.

A minor version bump was chosen because we drop support for Ruby 2.7.