### PR TITLE
Fix error when `from` is empty (Fixes #32)

### DIFF
--- a/lib/mailtrap/mail.rb
+++ b/lib/mailtrap/mail.rb
@@ -8,9 +8,9 @@ require_relative 'mail/from_template'
 module Mailtrap
   module Mail
     class << self
-      def from_message(message) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
+      def from_message(message) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         Mailtrap::Mail::Base.new(
-          from: prepare_address(address_list(message['from'])&.addresses&.first),
+          from: prepare_addresses(address_list(message['from'])&.addresses).first,
           to: prepare_addresses(address_list(message['to'])&.addresses),
           cc: prepare_addresses(address_list(message['cc'])&.addresses),
           bcc: prepare_addresses(address_list(message['bcc'])&.addresses),

--- a/spec/mailtrap/mail_spec.rb
+++ b/spec/mailtrap/mail_spec.rb
@@ -130,5 +130,17 @@ RSpec.describe Mailtrap::Mail do
         end
       end
     end
+
+    describe 'handling empty From correctly (#32)' do
+      let(:message_params) do
+        {
+          from: ''
+        }
+      end
+
+      # Does not raise an "undefined method `address` for nil"
+      # (There will be a "'from' is required" error from the server)
+      its(:from) { is_expected.to be_nil }
+    end
   end
 end


### PR DESCRIPTION
## Changes

- Handle case where `from` header is empty better. Existing code attempted to access the address without checking if it's present.

## How to test

- [ ] Attempt to send mail with an empty `from`. You should get a `'from' is required` error from the API server.