### PR TITLE
Handle Mail parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+## [2.1.2] - 2024-12-13
+
+- Improved handling of invalid `from`, `to`, `cc`, `bcc` headers when sending
+  with Action Mailer
+
 ## [2.1.1] - 2024-12-11
 
-- Improved handling of empty `from`
+- Improved handling of empty `from` header when sending with Action Mailer
 
 ## [2.1.0] - 2024-07-08
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mailtrap (2.1.1)
+    mailtrap (2.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/mailtrap/version.rb
+++ b/lib/mailtrap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mailtrap
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end

--- a/spec/mailtrap/mail_spec.rb
+++ b/spec/mailtrap/mail_spec.rb
@@ -142,5 +142,18 @@ RSpec.describe Mailtrap::Mail do
       # (There will be a "'from' is required" error from the server)
       its(:from) { is_expected.to be_nil }
     end
+
+    %i[from to cc bcc].each do |header|
+      context "when '#{header}' is invalid" do
+        let(:message_params) { super().merge(header => 'invalid email@example.com') }
+
+        it 'raises an error' do
+          expect { mail }.to raise_error(
+            Mailtrap::Error,
+            "failed to parse '#{header.capitalize}': 'invalid email@example.com'"
+          )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Motivation

Handle Mail parse error

## Changes

- Raise error when email address cannot be parsed

## How to test

- [ ] Try sending with invalid from, to, cc, bcc
- [ ] Try sending with valid from, to, cc, bcc

## Images and GIFs

N/A
