### PR TITLE
Drop Ruby 3.0 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.0.7'
           - '3.1.6'
-          - '3.2.4'
-          - '3.3.3'
-
+          - '3.2.7'
+          - '3.3.7'
+          - '3.4.2'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ inherit_mode:
     - Exclude
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   NewCops: enable
   Exclude:
     - "gemfiles/**/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.3.0] - 2025-03-06
+
+- Drop Ruby 3.0 support
+- Update dependencies
+
 ## [2.2.0] - 2024-12-18
 
 - Added `reply_to` parameter support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mailtrap (2.2.0)
+    mailtrap (2.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    date (3.3.4)
+    date (3.4.1)
     diff-lcs (1.5.1)
     hashdiff (1.1.0)
     json (2.7.2)
@@ -28,7 +28,7 @@ GEM
       net-pop
       net-smtp
     mini_mime (1.1.5)
-    net-imap (0.4.14)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -82,7 +82,7 @@ GEM
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     thor (1.3.1)
-    timeout (0.4.1)
+    timeout (0.4.3)
     unicode-display_width (2.5.0)
     vcr (6.2.0)
     webmock (3.23.1)
@@ -108,4 +108,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.5.14
+   2.6.5

--- a/lib/mailtrap/client.rb
+++ b/lib/mailtrap/client.rb
@@ -35,7 +35,7 @@ module Mailtrap
       raise ArgumentError, 'api_key is required' if api_key.nil?
       raise ArgumentError, 'api_port is required' if api_port.nil?
 
-      api_host ||= select_api_host(bulk: bulk, sandbox: sandbox)
+      api_host ||= select_api_host(bulk:, sandbox:)
       raise ArgumentError, 'inbox_id is required for sandbox API' if sandbox && inbox_id.nil?
 
       @api_key = api_key

--- a/lib/mailtrap/mail/base.rb
+++ b/lib/mailtrap/mail/base.rb
@@ -67,11 +67,11 @@ module Mailtrap
 
       def add_attachment(content:, filename:, type: nil, disposition: nil, content_id: nil)
         attachment = Mailtrap::Attachment.new(
-          content: content,
-          filename: filename,
-          type: type,
-          disposition: disposition,
-          content_id: content_id
+          content:,
+          filename:,
+          type:,
+          disposition:,
+          content_id:
         )
         attachments << attachment
 

--- a/lib/mailtrap/mail/from_template.rb
+++ b/lib/mailtrap/mail/from_template.rb
@@ -18,14 +18,14 @@ module Mailtrap
         template_variables: {}
       )
         super(
-          from: from,
-          to: to,
-          reply_to: reply_to,
-          cc: cc,
-          bcc: bcc,
-          attachments: attachments,
-          headers: headers,
-          custom_variables: custom_variables
+          from:,
+          to:,
+          reply_to:,
+          cc:,
+          bcc:,
+          attachments:,
+          headers:,
+          custom_variables:
         )
         @template_uuid = template_uuid
         @template_variables = template_variables

--- a/lib/mailtrap/version.rb
+++ b/lib/mailtrap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mailtrap
-  VERSION = '2.2.0'
+  VERSION = '2.3.0'
 end

--- a/mailtrap.gemspec
+++ b/mailtrap.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Official mailtrap.io API client'
   spec.homepage = 'https://github.com/railsware/mailtrap-ruby'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/railsware/mailtrap-ruby'

--- a/spec/mailtrap/attachment_spec.rb
+++ b/spec/mailtrap/attachment_spec.rb
@@ -6,11 +6,11 @@ require 'stringio'
 RSpec.describe Mailtrap::Attachment do
   subject(:attachment) do
     described_class.new(
-      content: content,
-      filename: filename,
-      type: type,
-      disposition: disposition,
-      content_id: content_id
+      content:,
+      filename:,
+      type:,
+      disposition:,
+      content_id:
     )
   end
 

--- a/spec/mailtrap/client_spec.rb
+++ b/spec/mailtrap/client_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Mailtrap::Client do
-  subject(:client) { described_class.new(api_key: api_key) }
+  subject(:client) { described_class.new(api_key:) }
 
   let(:api_key) { 'correct-api-key' }
 
@@ -65,7 +65,7 @@ RSpec.describe Mailtrap::Client do
 
       context 'with an alternative host' do
         let(:client) do
-          described_class.new(api_key: api_key, api_host: 'alternative.host.mailtrap.io', api_port: 8080)
+          described_class.new(api_key:, api_host: 'alternative.host.mailtrap.io', api_port: 8080)
         end
 
         it 'sending is successful' do
@@ -75,7 +75,7 @@ RSpec.describe Mailtrap::Client do
 
       context 'with bulk flag' do
         let(:client) do
-          described_class.new(api_key: api_key, bulk: true)
+          described_class.new(api_key:, bulk: true)
         end
 
         it 'chooses host for bulk sending' do
@@ -85,7 +85,7 @@ RSpec.describe Mailtrap::Client do
 
       context 'with bulk flag and alternative host' do
         let(:client) do
-          described_class.new(api_key: api_key, bulk: true, api_host: 'alternative.host.mailtrap.io', api_port: 8080)
+          described_class.new(api_key:, bulk: true, api_host: 'alternative.host.mailtrap.io', api_port: 8080)
         end
 
         it 'chooses alternative host' do
@@ -95,7 +95,7 @@ RSpec.describe Mailtrap::Client do
 
       context 'with sandbox flag' do
         let(:client) do
-          described_class.new(api_key: api_key, sandbox: true, inbox_id: 12)
+          described_class.new(api_key:, sandbox: true, inbox_id: 12)
         end
 
         it 'chooses host for sandbox sending' do
@@ -105,7 +105,7 @@ RSpec.describe Mailtrap::Client do
 
       context 'with sandbox flag without inbox id' do
         let(:client) do
-          described_class.new(api_key: api_key, sandbox: true)
+          described_class.new(api_key:, sandbox: true)
         end
 
         it { expect { send }.to raise_error(ArgumentError, 'inbox_id is required for sandbox API') }
@@ -113,7 +113,7 @@ RSpec.describe Mailtrap::Client do
 
       context 'with bulk and sandbox flag' do
         let(:client) do
-          described_class.new(api_key: api_key, bulk: true, sandbox: true)
+          described_class.new(api_key:, bulk: true, sandbox: true)
         end
 
         it { expect { send }.to raise_error(ArgumentError, 'bulk mode is not applicable for sandbox API') }
@@ -155,7 +155,7 @@ RSpec.describe Mailtrap::Client do
 
       context 'when using sandbox' do
         let(:client) do
-          described_class.new(api_key: api_key, sandbox: true, inbox_id: 13)
+          described_class.new(api_key:, sandbox: true, inbox_id: 13)
         end
 
         it 'sending is successful' do
@@ -178,7 +178,7 @@ RSpec.describe Mailtrap::Client do
     end
 
     def stub_api_send(status, body = nil)
-      stub = stub_request(:post, %r{/api/send}).to_return(status: status, body: body)
+      stub = stub_request(:post, %r{/api/send}).to_return(status:, body:)
       yield
       expect(stub).to have_been_requested
     end

--- a/spec/mailtrap/mail/base_spec.rb
+++ b/spec/mailtrap/mail/base_spec.rb
@@ -6,18 +6,18 @@ require_relative 'shared'
 RSpec.describe Mailtrap::Mail::Base do
   subject(:mail) do
     described_class.new(
-      from: from,
-      to: to,
-      reply_to: reply_to,
-      cc: cc,
-      bcc: bcc,
+      from:,
+      to:,
+      reply_to:,
+      cc:,
+      bcc:,
       subject: mail_subject,
-      text: text,
-      html: html,
-      attachments: attachments,
-      headers: headers,
-      category: category,
-      custom_variables: custom_variables
+      text:,
+      html:,
+      attachments:,
+      headers:,
+      category:,
+      custom_variables:
     )
   end
 

--- a/spec/mailtrap/mail/from_template_spec.rb
+++ b/spec/mailtrap/mail/from_template_spec.rb
@@ -6,16 +6,16 @@ require_relative 'shared'
 RSpec.describe Mailtrap::Mail::FromTemplate do
   subject(:mail) do
     described_class.new(
-      from: from,
-      to: to,
-      reply_to: reply_to,
-      cc: cc,
-      bcc: bcc,
-      attachments: attachments,
-      headers: headers,
-      custom_variables: custom_variables,
-      template_uuid: template_uuid,
-      template_variables: template_variables
+      from:,
+      to:,
+      reply_to:,
+      cc:,
+      bcc:,
+      attachments:,
+      headers:,
+      custom_variables:,
+      template_uuid:,
+      template_variables:
     )
   end
 


### PR DESCRIPTION
## Motivation

Ruby 3.0 reached end of life in April 2024.

## Changes

- Drop Ruby 3.0 support
- Bump net-imap (fixes https://github.com/railsware/mailtrap-ruby/security/dependabot/6)
- Fix Style/HashSyntax offenses
- Bump version to 2.3.0

## How to test

- [ ] Not needed.

## Images and GIFs

None.