### PR TITLE
Add Email Templates API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.4.0] - 2025-05-12
+
+- Added Email Templates API support
+
 ## [2.3.0] - 2025-03-06
 
 - Drop Ruby 3.0 support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mailtrap (2.3.0)
+    mailtrap (2.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -66,7 +66,15 @@ Refer to the [`examples`](examples) folder for more examples.
 
 - [Full](examples/full.rb)
 - [Email template](examples/email_template.rb)
+- [Email templates management](examples/email_templates.rb)
 - [ActionMailer](examples/action_mailer.rb)
+
+### Email Templates management
+
+```ruby
+client = Mailtrap::EmailTemplates.new(api_key: 'your-api-key')
+templates = client.all(account_id: 1)
+```
 
 ### Content-Transfer-Encoding
 

--- a/examples/email_templates.rb
+++ b/examples/email_templates.rb
@@ -1,0 +1,26 @@
+require 'mailtrap'
+
+client = Mailtrap::EmailTemplates.new(api_key: 'your-api-key')
+account_id = 1
+
+# list templates
+client.all(account_id:)
+
+# create template
+created = client.create(
+  account_id:,
+  name: 'Newsletter Template',
+  subject: 'Subject',
+  category: 'Newsletter',
+  body_html: '<div>Hello</div>'
+)
+
+# update template
+client.update(
+  account_id:,
+  email_template_id: created[:id],
+  name: 'Updated Template'
+)
+
+# delete template
+client.delete(account_id:, email_template_id: created[:id])

--- a/lib/mailtrap.rb
+++ b/lib/mailtrap.rb
@@ -4,5 +4,6 @@ require_relative 'mailtrap/action_mailer' if defined? ActionMailer
 require_relative 'mailtrap/mail'
 require_relative 'mailtrap/errors'
 require_relative 'mailtrap/version'
+require_relative 'mailtrap/email_templates'
 
 module Mailtrap; end

--- a/lib/mailtrap/email_templates.rb
+++ b/lib/mailtrap/email_templates.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Mailtrap
+  class EmailTemplates < Client
+    API_HOST = 'mailtrap.io'
+    API_PORT = 443
+
+    def initialize(api_key:, api_host: API_HOST, api_port: API_PORT)
+      super
+    end
+
+    def all(account_id:)
+      request(:get, "/api/accounts/#{account_id}/email_templates")
+    end
+
+    def create(account_id:, **params)
+      request(:post, "/api/accounts/#{account_id}/email_templates", params)
+    end
+
+    def update(account_id:, email_template_id:, **params)
+      request(
+        :patch,
+        "/api/accounts/#{account_id}/email_templates/#{email_template_id}",
+        params
+      )
+    end
+
+    def delete(account_id:, email_template_id:)
+      request(:delete, "/api/accounts/#{account_id}/email_templates/#{email_template_id}")
+      true
+    end
+
+    private
+
+    def request(http_method, path, body = nil) # rubocop:disable Metrics/MethodLength
+      request_class = {
+        get: Net::HTTP::Get,
+        post: Net::HTTP::Post,
+        patch: Net::HTTP::Patch,
+        delete: Net::HTTP::Delete
+      }.fetch(http_method)
+
+      request = request_class.new(path)
+      request['Authorization'] = "Bearer #{api_key}"
+      request['User-Agent'] = 'mailtrap-ruby (https://github.com/railsware/mailtrap-ruby)'
+      if body
+        request['Content-Type'] = 'application/json'
+        request.body = JSON.generate(body)
+      end
+
+      response = http_client.request(request)
+      handle_response(response)
+    end # rubocop:enable Metrics/MethodLength
+
+    def handle_response(response) # rubocop:disable Metrics/MethodLength
+      case response
+      when Net::HTTPNoContent
+        true
+      when Net::HTTPSuccess
+        json_response(response.body)
+      when Net::HTTPUnauthorized
+        raise Mailtrap::AuthorizationError, json_response(response.body)[:errors]
+      when Net::HTTPForbidden
+        raise Mailtrap::RejectionError, json_response(response.body)[:errors]
+      when Net::HTTPClientError, Net::HTTPServerError
+        raise Mailtrap::Error, json_response(response.body)[:errors]
+      else
+        raise Mailtrap::Error, ["unexpected status code=#{response.code}"]
+      end
+    end # rubocop:enable Metrics/MethodLength
+  end
+end

--- a/lib/mailtrap/version.rb
+++ b/lib/mailtrap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mailtrap
-  VERSION = '2.3.0'
+  VERSION = '2.4.0'
 end

--- a/spec/mailtrap/email_templates_spec.rb
+++ b/spec/mailtrap/email_templates_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe Mailtrap::EmailTemplates do
+  subject(:templates) { described_class.new(api_key:) }
+
+  let(:api_key) { 'correct-api-key' }
+  let(:account_id) { 123 }
+  let(:template_id) { 456 }
+
+  def stub_api(method, path, status:, body: nil)
+    stub = stub_request(method, "https://mailtrap.io#{path}")
+           .to_return(status:, body:)
+    yield
+    expect(stub).to have_been_requested
+  end
+
+  describe '#all' do
+    it 'returns templates list' do
+      stub_api(:get, "/api/accounts/#{account_id}/email_templates", status: 200, body: '[{"id":1}]') do
+        expect(templates.all(account_id:)).to eq([{ id: 1 }])
+      end
+    end
+  end
+
+  describe '#create' do
+    let(:params) { { name: 'Test', subject: 'Subj', category: 'Promotion', body_html: '<div>body</div>' } }
+
+    it 'sends POST request with JSON body' do
+      stub = stub_request(:post, "https://mailtrap.io/api/accounts/#{account_id}/email_templates")
+             .with(body: params.to_json)
+             .to_return(status: 201, body: '{"id":2}')
+      expect(templates.create(account_id:, **params)).to eq({ id: 2 })
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe '#update' do
+    it 'sends PATCH request with JSON body' do # rubocop:disable RSpec/ExampleLength
+      stub = stub_request(:patch, "https://mailtrap.io/api/accounts/#{account_id}/email_templates/#{template_id}")
+             .with(body: { name: 'Updated' }.to_json)
+             .to_return(status: 200, body: '{"id":2,"name":"Updated"}')
+      expect(templates.update(account_id:, email_template_id: template_id,
+                              name: 'Updated')).to eq({ id: 2, name: 'Updated' })
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe '#delete' do
+    it 'sends DELETE request' do
+      stub_api(:delete, "/api/accounts/#{account_id}/email_templates/#{template_id}", status: 204) do
+        expect(templates.delete(account_id:, email_template_id: template_id)).to be true
+      end
+    end
+  end
+
+  describe 'error handling' do
+    it 'raises authorization error' do
+      stub_api(:get, "/api/accounts/#{account_id}/email_templates", status: 401, body: '{"errors":["Unauthorized"]}') do
+        expect { templates.all(account_id:) }.to raise_error(Mailtrap::AuthorizationError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- support email templates CRUD API
- expose new EmailTemplates client in gem
- provide usage snippet and example in README
- bump version to 2.4.0
- refactor EmailTemplates to inherit from Client for shared HTTP logic

## Testing
- `bundle exec rubocop`
- `bundle exec rake spec`
