### PR TITLE
Add Email Templates API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.4.0] - 2025-05-12
+
+- Added Email Templates API support
+- Introduced template management methods on `Mailtrap::Client`
+
 ## [2.3.0] - 2025-03-06
 
 - Drop Ruby 3.0 support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mailtrap (2.3.0)
+    mailtrap (2.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -66,7 +66,15 @@ Refer to the [`examples`](examples) folder for more examples.
 
 - [Full](examples/full.rb)
 - [Email template](examples/email_template.rb)
+- [Email templates management](examples/email_templates.rb)
 - [ActionMailer](examples/action_mailer.rb)
+
+### Email Templates management
+
+```ruby
+client = Mailtrap::Client.new(api_key: 'your-api-key')
+templates = client.list_templates(account_id: 1)
+```
 
 ### Content-Transfer-Encoding
 

--- a/examples/email_templates.rb
+++ b/examples/email_templates.rb
@@ -1,0 +1,26 @@
+require 'mailtrap'
+
+client = Mailtrap::Client.new(api_key: 'your-api-key')
+account_id = 1
+
+# list templates
+client.list_templates(account_id:)
+
+# create template
+created = client.create_template(
+  account_id:,
+  name: 'Newsletter Template',
+  subject: 'Subject',
+  category: 'Newsletter',
+  body_html: '<div>Hello</div>'
+)
+
+# update template
+client.update_template(
+  account_id:,
+  email_template_id: created[:id],
+  name: 'Updated Template'
+)
+
+# delete template
+client.destroy_template(account_id:, email_template_id: created[:id])

--- a/lib/mailtrap.rb
+++ b/lib/mailtrap.rb
@@ -4,5 +4,6 @@ require_relative 'mailtrap/action_mailer' if defined? ActionMailer
 require_relative 'mailtrap/mail'
 require_relative 'mailtrap/errors'
 require_relative 'mailtrap/version'
+require_relative 'mailtrap/client'
 
 module Mailtrap; end

--- a/lib/mailtrap/version.rb
+++ b/lib/mailtrap/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mailtrap
-  VERSION = '2.3.0'
+  VERSION = '2.4.0'
 end

--- a/spec/mailtrap/client_templates_spec.rb
+++ b/spec/mailtrap/client_templates_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe Mailtrap::Client do
+  subject(:client) { described_class.new(api_key:) }
+
+  let(:api_key) { 'correct-api-key' }
+  let(:account_id) { 123 }
+  let(:template_id) { 456 }
+
+  def stub_api(method, path, status:, body: nil)
+    stub = stub_request(method, "https://mailtrap.io#{path}")
+           .to_return(status:, body:)
+    yield
+    expect(stub).to have_been_requested
+  end
+
+  describe '#list_templates' do
+    it 'returns templates list' do
+      stub_api(:get, "/api/accounts/#{account_id}/email_templates", status: 200, body: '[{"id":1}]') do
+        expect(client.list_templates(account_id:)).to eq([{ id: 1 }])
+      end
+    end
+  end
+
+  describe '#create_template' do
+    let(:params) { { name: 'Test', subject: 'Subj', category: 'Promotion', body_html: '<div>body</div>' } }
+
+    it 'sends POST request with JSON body' do
+      stub = stub_request(:post, "https://mailtrap.io/api/accounts/#{account_id}/email_templates")
+             .with(body: params.to_json)
+             .to_return(status: 201, body: '{"id":2}')
+      expect(client.create_template(account_id:, **params)).to eq({ id: 2 })
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe '#update_template' do
+    it 'sends PATCH request with JSON body' do # rubocop:disable RSpec/ExampleLength
+      stub = stub_request(:patch, "https://mailtrap.io/api/accounts/#{account_id}/email_templates/#{template_id}")
+             .with(body: { name: 'Updated' }.to_json)
+             .to_return(status: 200, body: '{"id":2,"name":"Updated"}')
+      expect(
+        client.update_template(account_id:, email_template_id: template_id, name: 'Updated')
+      ).to eq({ id: 2, name: 'Updated' })
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe '#destroy_template' do
+    it 'sends DELETE request' do
+      stub_api(:delete, "/api/accounts/#{account_id}/email_templates/#{template_id}", status: 204) do
+        expect(client.destroy_template(account_id:, email_template_id: template_id)).to be true
+      end
+    end
+  end
+
+  describe 'error handling' do
+    it 'raises authorization error' do
+      stub_api(:get, "/api/accounts/#{account_id}/email_templates", status: 401, body: '{"errors":["Unauthorized"]}') do
+        expect { client.list_templates(account_id:) }.to raise_error(Mailtrap::AuthorizationError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- support email templates CRUD API
- expose new EmailTemplates client in gem
- provide usage snippet and example in README
- bump version to 2.4.0

## Testing
- `bundle exec rubocop`
- `bundle exec rake spec`
