### PR TITLE
added ContactImportAPI

### DIFF
--- a/examples/contacts_api.rb
+++ b/examples/contacts_api.rb
@@ -4,6 +4,7 @@ client = Mailtrap::Client.new(api_key: 'your-api-key')
 contact_lists = Mailtrap::ContactListsAPI.new 3229, client
 contacts = Mailtrap::ContactsAPI.new 3229, client
 contact_fields = Mailtrap::ContactFieldsAPI.new 3229, client
+contact_imports = Mailtrap::ContactImportsAPI.new 3229, client
 
 # Set your API credentials as environment variables
 # export MAILTRAP_API_KEY='your-api-key'
@@ -12,6 +13,7 @@ contact_fields = Mailtrap::ContactFieldsAPI.new 3229, client
 # contact_lists = Mailtrap::ContactListsAPI.new
 # contacts = Mailtrap::ContactsAPI.new
 # contact_fields = Mailtrap::ContactFieldsAPI.new
+# contact_imports = Mailtrap::ContactImportsAPI.new
 
 # Create new contact list
 list = contact_lists.create(name: 'Test List')
@@ -135,8 +137,41 @@ contacts.add_to_lists(contact.id, [list.id])
 # Delete contact
 contacts.delete(contact.id)
 
-# Delete contact list
-contact_lists.delete(list.id)
-
 # Delete contact field
 contact_fields.delete(field.id)
+
+# Create a new contact import
+contact_import = contact_imports.create(
+  [
+    {
+      email: 'imported@example.com',
+      fields: {
+        first_name: 'Jane',
+      },
+      list_ids_included: [list.id],
+      list_ids_excluded: []
+    }
+  ]
+)
+# => ContactImport.new(
+#      id: 1,
+#      status: 'created',
+#      list_ids: [1],
+#      created_contacts_count: 1,
+#      updated_contacts_count: 0,
+#      contacts_over_limit_count: 0
+#    )
+
+# Get a contact import by ID
+contact_imports.get(contact_import.id)
+# => ContactImport.new(
+#      id: 1,
+#      status: 'started',
+#      list_ids: [1],
+#      created_contacts_count: 1,
+#      updated_contacts_count: 0,
+#      contacts_over_limit_count: 0
+#    )
+
+# Delete contact list
+contact_lists.delete(list.id)

--- a/examples/contacts_api.rb
+++ b/examples/contacts_api.rb
@@ -173,5 +173,61 @@ contact_imports.get(contact_import.id)
 #      contacts_over_limit_count: 0
 #    )
 
+# Create a new contact import using ContactsImportRequest builder
+import_request = Mailtrap::ContactsImportRequest.new
+
+# Add contacts using the builder pattern
+import_request
+  .upsert(
+    email: 'john.doe@example.com',
+    fields: { first_name: 'John' }
+  )
+  .add_to_lists(email: 'john.doe@example.com', list_ids: [list.id])
+  .upsert(
+    email: 'jane.smith@example.com',
+    fields: { first_name: 'Jane' }
+  )
+  .add_to_lists(email: 'jane.smith@example.com', list_ids: [list.id])
+  .remove_from_lists(email: 'jane.smith@example.com', list_ids: [])
+
+# Execute the import
+contact_imports.create(import_request)
+# => ContactImport.new(
+#      id: 2,
+#      status: 'created',
+#      list_ids: [1],
+#      created_contacts_count: 2,
+#      updated_contacts_count: 0,
+#      contacts_over_limit_count: 0
+#    )
+
+# Alternative: Step-by-step building
+builder = Mailtrap::ContactsImportRequest.new
+builder.upsert(email: 'jane.doe@example.com', fields: { first_name: 'Jane' })
+builder.add_to_lists(email: 'jane.doe@example.com', list_ids: [list.id])
+
+contact_import_2 = contact_imports.create(builder)
+# => ContactImport.new(
+#      id: 3,
+#      status: 'created',
+#      list_ids: [1],
+#      created_contacts_count: 1,
+#      updated_contacts_count: 0,
+#      contacts_over_limit_count: 0
+#    )
+
+sleep 3 # Wait for the import to complete (if needed)
+
+# Get the import status
+contact_imports.get(contact_import_2.id)
+# => ContactImport.new(
+#      id: 3,
+#      status: 'completed',
+#      list_ids: [1],
+#      created_contacts_count: 1,
+#      updated_contacts_count: 0,
+#      contacts_over_limit_count: 0
+#    )
+
 # Delete contact list
 contact_lists.delete(list.id)

--- a/lib/mailtrap.rb
+++ b/lib/mailtrap.rb
@@ -8,6 +8,7 @@ require_relative 'mailtrap/email_templates_api'
 require_relative 'mailtrap/contacts_api'
 require_relative 'mailtrap/contact_lists_api'
 require_relative 'mailtrap/contact_fields_api'
+require_relative 'mailtrap/contact_imports_api'
 
 module Mailtrap
   # @!macro api_errors

--- a/lib/mailtrap/contact_import.rb
+++ b/lib/mailtrap/contact_import.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Mailtrap
+  # Data Transfer Object for Contact Import
+  # @attr_reader id [String] The contact import ID
+  # @attr_reader status [String] The status of the import (created, started, finished, failed)
+  # @attr_reader created_contacts_count [Integer, nil] Number of contacts created in this import
+  # @attr_reader updated_contacts_count [Integer, nil] Number of contacts updated in this import
+  # @attr_reader contacts_over_limit_count [Integer, nil] Number of contacts over the allowed limit
+  ContactImport = Struct.new(
+    :id,
+    :status,
+    :created_contacts_count,
+    :updated_contacts_count,
+    :contacts_over_limit_count,
+    keyword_init: true
+  ) do
+    # @return [Hash] The contact attributes as a hash
+    def to_h
+      super.compact
+    end
+  end
+end

--- a/lib/mailtrap/contact_imports_api.rb
+++ b/lib/mailtrap/contact_imports_api.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative 'contact_import'
+
+module Mailtrap
+  class ContactImportsAPI
+    include BaseAPI
+
+    self.supported_options = %i[email fields list_ids_included list_ids_excluded]
+
+    self.response_class = ContactImport
+
+    # Retrieves a specific contact import
+    # @param import_id [String] The contact import identifier
+    # @return [ContactImport] Contact import object
+    # @!macro api_errors
+    def get(import_id)
+      base_get(import_id)
+    end
+
+    # Create contacts import
+    # @param contacts [Array<Hash>] Array of contact objects to import
+    #   Each contact object should have the following keys:
+    #   - email [String] The contact's email address
+    #   - fields [Hash] Object of fields in the format: field_merge_tag => String, Integer, Float, Boolean, or ISO-8601 date string (yyyy-mm-dd) # rubocop:disable Layout/LineLength
+    #   - list_ids_included [Array<Integer>] List IDs to include the contact in
+    #   - list_ids_excluded [Array<Integer>] List IDs to exclude the contact from
+    # @return [ContactImport] Created contact list object
+    # @!macro api_errors
+    # @raise [ArgumentError] If invalid options are provided
+    def create(contacts)
+      contacts.each do |contact|
+        validate_options!(contact, supported_options)
+      end
+      response = client.post(base_path, contacts:)
+      handle_response(response)
+    end
+
+    private
+
+    def base_path
+      "/api/accounts/#{account_id}/contacts/imports"
+    end
+  end
+end

--- a/lib/mailtrap/contact_imports_api.rb
+++ b/lib/mailtrap/contact_imports_api.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'contact_import'
+require_relative 'contacts_import_request'
 
 module Mailtrap
   class ContactImportsAPI
@@ -19,8 +20,9 @@ module Mailtrap
     end
 
     # Create contacts import
-    # @param contacts [Array<Hash>] Array of contact objects to import
-    #   Each contact object should have the following keys:
+    # @param contacts [Array<Hash>, ContactsImportRequest, #to_a] Any object that responds to #to_a and returns an array of contact hashes. # rubocop:disable Layout/LineLength
+    #   Accepts Array<Hash>, ContactsImportRequest, or any other object implementing #to_a
+    #   When using Array<Hash>, each contact object should have the following keys:
     #   - email [String] The contact's email address
     #   - fields [Hash] Object of fields in the format: field_merge_tag => String, Integer, Float, Boolean, or ISO-8601 date string (yyyy-mm-dd) # rubocop:disable Layout/LineLength
     #   - list_ids_included [Array<Integer>] List IDs to include the contact in
@@ -29,12 +31,14 @@ module Mailtrap
     # @!macro api_errors
     # @raise [ArgumentError] If invalid options are provided
     def create(contacts)
-      contacts.each do |contact|
+      contact_data = contacts.to_a
+      contact_data.each do |contact|
         validate_options!(contact, supported_options)
       end
-      response = client.post(base_path, contacts:)
+      response = client.post(base_path, contacts: contact_data)
       handle_response(response)
     end
+    alias start create
 
     private
 

--- a/lib/mailtrap/contacts_import_request.rb
+++ b/lib/mailtrap/contacts_import_request.rb
@@ -18,7 +18,7 @@ module Mailtrap
         return self
       end
 
-      @data[email][:fields] = fields
+      @data[email][:fields].merge!(fields)
 
       self
     end
@@ -33,7 +33,7 @@ module Mailtrap
         return self
       end
 
-      @data[email][:list_ids_included].concat(list_ids)
+      @data[email][:list_ids_included] |= list_ids
 
       self
     end
@@ -48,7 +48,7 @@ module Mailtrap
         return self
       end
 
-      @data[email][:list_ids_excluded].concat(list_ids)
+      @data[email][:list_ids_excluded] |= list_ids
 
       self
     end

--- a/lib/mailtrap/contacts_import_request.rb
+++ b/lib/mailtrap/contacts_import_request.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Mailtrap
+  # A builder class for creating contact import requests
+  # Allows you to build a collection of contacts with their associated fields and list memberships
+  class ContactsImportRequest
+    def initialize
+      @data = {}
+    end
+
+    # Creates or updates a contact with the provided email and fields
+    # @param email [String] The contact's email address
+    # @param fields [Hash] Contact fields in the format: field_merge_tag => String, Integer, Float, Boolean, or ISO-8601 date string (yyyy-mm-dd) # rubocop:disable Layout/LineLength
+    # @return [ContactsImportRequest] Returns self for method chaining
+    def upsert(email:, fields: {})
+      unless @data[email]
+        @data[email] = { email:, fields:, list_ids_included: [], list_ids_excluded: [] }
+        return self
+      end
+
+      @data[email][:fields] = fields
+
+      self
+    end
+
+    # Adds a contact to the specified lists
+    # @param email [String] The contact's email address
+    # @param list_ids [Array<Integer>] Array of list IDs to add the contact to
+    # @return [ContactsImportRequest] Returns self for method chaining
+    def add_to_lists(email:, list_ids:)
+      unless @data[email]
+        @data[email] = { email:, fields: {}, list_ids_included: list_ids, list_ids_excluded: [] }
+        return self
+      end
+
+      @data[email][:list_ids_included].concat(list_ids)
+
+      self
+    end
+
+    # Removes a contact from the specified lists
+    # @param email [String] The contact's email address
+    # @param list_ids [Array<Integer>] Array of list IDs to remove the contact from
+    # @return [ContactsImportRequest] Returns self for method chaining
+    def remove_from_lists(email:, list_ids:)
+      unless @data[email]
+        @data[email] = { email:, fields: {}, list_ids_included: [], list_ids_excluded: list_ids }
+        return self
+      end
+
+      @data[email][:list_ids_excluded].concat(list_ids)
+
+      self
+    end
+
+    # Converts the import request to a JSON-serializable array
+    # @return [Array<Hash>] Array of contact objects ready for import
+    def as_json
+      @data.values
+    end
+    alias to_a as_json
+  end
+end

--- a/spec/mailtrap/contact_imports_api_spec.rb
+++ b/spec/mailtrap/contact_imports_api_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+RSpec.describe Mailtrap::ContactImportsAPI do
+  let(:client) { described_class.new('1111111', Mailtrap::Client.new(api_key: 'correct-api-key')) }
+  let(:base_url) { 'https://mailtrap.io/api/accounts/1111111' }
+
+  describe '#get' do
+    let(:import_id) { 'import-123' }
+    let(:expected_response) do
+      {
+        'id' => 'import-123',
+        'status' => 'finished',
+        'created_contacts_count' => 10,
+        'updated_contacts_count' => 2,
+        'contacts_over_limit_count' => 0
+      }
+    end
+
+    it 'returns a specific contact import' do
+      stub_request(:get, "#{base_url}/contacts/imports/#{import_id}")
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      response = client.get(import_id)
+      expect(response).to have_attributes(
+        id: 'import-123',
+        status: 'finished',
+        created_contacts_count: 10,
+        updated_contacts_count: 2,
+        contacts_over_limit_count: 0
+      )
+    end
+
+    it 'raises error when contact import not found' do
+      stub_request(:get, "#{base_url}/contacts/imports/not-found")
+        .to_return(
+          status: 404,
+          body: { 'error' => 'Not Found' }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect { client.get('not-found') }.to raise_error(Mailtrap::Error)
+    end
+  end
+
+  describe '#create' do
+    let(:contacts) do
+      [
+        {
+          email: 'example@example.com',
+          fields: {
+            fname: 'John',
+            age: 30,
+            is_subscribed: true,
+            birthday: '1990-05-15'
+          },
+          list_ids_included: [1, 2],
+          list_ids_excluded: [3]
+        }
+      ]
+    end
+    let(:expected_response) do
+      {
+        'id' => 'import-456',
+        'status' => 'created',
+        'created_contacts_count' => 1,
+        'updated_contacts_count' => 0,
+        'contacts_over_limit_count' => 0
+      }
+    end
+
+    it 'creates a new contact import with hash' do
+      stub_request(:post, "#{base_url}/contacts/imports")
+        .with(body: { contacts: }.to_json)
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      response = client.create(contacts)
+      expect(response).to have_attributes(
+        id: 'import-456',
+        status: 'created',
+        created_contacts_count: 1,
+        updated_contacts_count: 0,
+        contacts_over_limit_count: 0
+      )
+    end
+
+    it 'raises error when invalid options are provided' do
+      invalid_contacts = [contacts.first.merge(foo: 'bar')]
+      expect { client.create(invalid_contacts) }.to raise_error(ArgumentError, /invalid options are given/)
+    end
+
+    it 'raises error when API returns an error' do
+      stub_request(:post, "#{base_url}/contacts/imports")
+        .with(body: { contacts: }.to_json)
+        .to_return(
+          status: 422,
+          body: { 'errors' => { 'email' => ['is invalid'] } }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect { client.create(contacts) }.to raise_error(Mailtrap::Error)
+    end
+  end
+end

--- a/spec/mailtrap/contact_imports_api_spec.rb
+++ b/spec/mailtrap/contact_imports_api_spec.rb
@@ -185,4 +185,51 @@ RSpec.describe Mailtrap::ContactImportsAPI do
       end
     end
   end
+
+  describe '#start' do
+    let(:contacts) do
+      [
+        {
+          email: 'example@example.com',
+          fields: {
+            fname: 'John',
+            age: 30,
+            is_subscribed: true,
+            birthday: '1990-05-15'
+          },
+          list_ids_included: [1, 2],
+          list_ids_excluded: [3]
+        }
+      ]
+    end
+
+    let(:expected_response) do
+      {
+        'id' => 'import-789',
+        'status' => 'created',
+        'created_contacts_count' => 1,
+        'updated_contacts_count' => 0,
+        'contacts_over_limit_count' => 0
+      }
+    end
+
+    it 'is an alias for #create and works identically' do
+      stub_request(:post, "#{base_url}/contacts/imports")
+        .with(body: { contacts: }.to_json)
+        .to_return(
+          status: 200,
+          body: expected_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      response = client.start(contacts)
+      expect(response).to have_attributes(
+        id: 'import-789',
+        status: 'created',
+        created_contacts_count: 1,
+        updated_contacts_count: 0,
+        contacts_over_limit_count: 0
+      )
+    end
+  end
 end

--- a/spec/mailtrap/contact_imports_api_spec.rb
+++ b/spec/mailtrap/contact_imports_api_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Mailtrap::ContactImportsAPI do
         end
       end
 
-      describe 'step-by-step method calls' do
+      describe 'step-by-step method calls' do # rubocop:disable RSpec/MultipleMemoizedHelpers
         let(:request) do
           req = Mailtrap::ContactsImportRequest.new
           req.upsert(email: basic_contact_data[:email], fields: basic_contact_data[:fields])

--- a/spec/mailtrap/contacts_import_request_spec.rb
+++ b/spec/mailtrap/contacts_import_request_spec.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+RSpec.describe Mailtrap::ContactsImportRequest do
+  subject(:request) { described_class.new }
+
+  # Test data
+  let(:test_email) { 'john.doe@example.com' }
+  let(:another_email) { 'jane.smith@example.com' }
+  let(:test_fields) { { first_name: 'John', last_name: 'Doe' } }
+  let(:additional_fields) { { age: 30, company: 'Example Corp' } }
+  let(:test_list_ids) { [1, 2, 3] }
+
+  # Shared examples for method chaining
+  shared_examples 'supports method chaining' do |method_name, **args|
+    it 'returns self for method chaining' do
+      result = request.public_send(method_name, **args)
+      expect(result).to eq(request)
+    end
+  end
+
+  # Shared examples for contact creation
+  shared_examples 'creates contact when not exists' do |method_name, expected_data, **method_args|
+    it "creates a new contact using #{method_name}" do
+      result = request.public_send(method_name, **method_args)
+
+      expect(result).to eq(request)
+      expect(request.as_json).to contain_exactly(expected_data)
+    end
+  end
+
+  describe '#upsert' do
+    include_examples 'supports method chaining', :upsert, email: 'test@example.com', fields: { name: 'Test' }
+
+    context 'when contact does not exist' do
+      include_examples 'creates contact when not exists', :upsert, {
+        email: 'john.doe@example.com',
+        fields: { first_name: 'John', last_name: 'Doe' },
+        list_ids_included: [],
+        list_ids_excluded: []
+      }, email: 'john.doe@example.com', fields: { first_name: 'John', last_name: 'Doe' }
+
+      it 'creates a contact with empty fields when none provided' do
+        result = request.upsert(email: test_email)
+
+        expect(result).to eq(request)
+        expect(request.as_json).to contain_exactly(
+          email: test_email,
+          fields: {},
+          list_ids_included: [],
+          list_ids_excluded: []
+        )
+      end
+    end
+
+    context 'when contact already exists' do
+      before { request.upsert(email: test_email, fields: { first_name: 'John' }) }
+
+      it 'merges new fields with existing fields' do
+        result = request.upsert(email: test_email, fields: additional_fields)
+
+        expect(result).to eq(request)
+        expect(request.as_json).to contain_exactly(
+          email: test_email,
+          fields: { first_name: 'John', **additional_fields },
+          list_ids_included: [],
+          list_ids_excluded: []
+        )
+      end
+
+      it 'overwrites existing field values' do
+        result = request.upsert(email: test_email, fields: { first_name: 'Jane' })
+
+        expect(result).to eq(request)
+        expect(request.as_json).to contain_exactly(
+          email: test_email,
+          fields: { first_name: 'Jane' },
+          list_ids_included: [],
+          list_ids_excluded: []
+        )
+      end
+
+      it 'preserves existing list associations when upserting fields' do
+        request.add_to_lists(email: test_email, list_ids: [1, 2])
+        request.remove_from_lists(email: test_email, list_ids: [3])
+
+        request.upsert(email: test_email, fields: { last_name: 'Doe' })
+
+        expect(request.as_json).to contain_exactly(
+          email: test_email,
+          fields: { first_name: 'John', last_name: 'Doe' },
+          list_ids_included: [1, 2],
+          list_ids_excluded: [3]
+        )
+      end
+    end
+  end
+
+  describe '#add_to_lists' do
+    include_examples 'supports method chaining', :add_to_lists, email: 'test@example.com', list_ids: [1, 2]
+
+    context 'when contact does not exist' do
+      include_examples 'creates contact when not exists', :add_to_lists, {
+        email: 'jane.doe@example.com',
+        fields: {},
+        list_ids_included: [1, 2, 3],
+        list_ids_excluded: []
+      }, email: 'jane.doe@example.com', list_ids: [1, 2, 3]
+    end
+
+    context 'when contact already exists' do
+      before { request.upsert(email: another_email, fields: { name: 'Jane' }) }
+
+      it 'adds new list IDs to existing inclusions' do
+        request.add_to_lists(email: another_email, list_ids: [1, 2])
+        result = request.add_to_lists(email: another_email, list_ids: [3, 4])
+
+        expect(result).to eq(request)
+        expect(request.as_json).to contain_exactly(
+          email: another_email,
+          fields: { name: 'Jane' },
+          list_ids_included: [1, 2, 3, 4],
+          list_ids_excluded: []
+        )
+      end
+
+      it 'prevents duplicate list IDs in inclusions' do
+        request.add_to_lists(email: another_email, list_ids: [1, 2])
+        result = request.add_to_lists(email: another_email, list_ids: [2, 3])
+
+        expect(result).to eq(request)
+        expect(request.as_json).to contain_exactly(
+          email: another_email,
+          fields: { name: 'Jane' },
+          list_ids_included: [1, 2, 3],
+          list_ids_excluded: []
+        )
+      end
+    end
+
+    it 'works with method chaining on same email' do
+      request
+        .add_to_lists(email: test_email, list_ids: [1, 2])
+        .add_to_lists(email: test_email, list_ids: [3, 4])
+
+      expect(request.as_json.first[:list_ids_included]).to eq([1, 2, 3, 4])
+    end
+  end
+
+  describe '#remove_from_lists' do
+    include_examples 'supports method chaining', :remove_from_lists, email: 'test@example.com', list_ids: [5, 6]
+
+    context 'when contact does not exist' do
+      include_examples 'creates contact when not exists', :remove_from_lists, {
+        email: 'bob.smith@example.com',
+        fields: {},
+        list_ids_included: [],
+        list_ids_excluded: [5, 6, 7]
+      }, email: 'bob.smith@example.com', list_ids: [5, 6, 7]
+    end
+
+    context 'when contact already exists' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:bob_email) { 'bob.smith@example.com' }
+
+      before { request.upsert(email: bob_email, fields: { name: 'Bob' }) }
+
+      it 'adds new list IDs to existing exclusions' do
+        request.remove_from_lists(email: bob_email, list_ids: [5, 6])
+        result = request.remove_from_lists(email: bob_email, list_ids: [7, 8])
+
+        expect(result).to eq(request)
+        expect(request.as_json).to contain_exactly(
+          email: bob_email,
+          fields: { name: 'Bob' },
+          list_ids_included: [],
+          list_ids_excluded: [5, 6, 7, 8]
+        )
+      end
+
+      it 'prevents duplicate list IDs in exclusions' do
+        request.remove_from_lists(email: bob_email, list_ids: [5, 6])
+        result = request.remove_from_lists(email: bob_email, list_ids: [6, 7])
+
+        expect(result).to eq(request)
+        expect(request.as_json).to contain_exactly(
+          email: bob_email,
+          fields: { name: 'Bob' },
+          list_ids_included: [],
+          list_ids_excluded: [5, 6, 7]
+        )
+      end
+    end
+
+    it 'works with method chaining on same email' do
+      request
+        .remove_from_lists(email: test_email, list_ids: [5, 6])
+        .remove_from_lists(email: test_email, list_ids: [7, 8])
+
+      expect(request.as_json.first[:list_ids_excluded]).to eq([5, 6, 7, 8])
+    end
+  end
+
+  describe 'serialization methods' do
+    describe '#as_json' do
+      context 'when no contacts added' do
+        it 'returns an empty array' do
+          expect(request.as_json).to eq([])
+        end
+      end
+
+      context 'when contacts are added' do
+        before do
+          request
+            .upsert(email: test_email, fields: { name: 'John' })
+            .add_to_lists(email: test_email, list_ids: [1])
+            .upsert(email: another_email, fields: { name: 'Jane' })
+            .remove_from_lists(email: another_email, list_ids: [2])
+        end
+
+        it 'returns array of contact data hashes' do
+          result = request.as_json
+
+          expect(result).to contain_exactly(
+            {
+              email: test_email,
+              fields: { name: 'John' },
+              list_ids_included: [1],
+              list_ids_excluded: []
+            },
+            {
+              email: another_email,
+              fields: { name: 'Jane' },
+              list_ids_included: [],
+              list_ids_excluded: [2]
+            }
+          )
+        end
+      end
+    end
+
+    describe '#to_a' do
+      it 'is an alias for #as_json' do
+        request.upsert(email: 'test@example.com', fields: { name: 'Test' })
+
+        expect(request.to_a).to eq(request.as_json)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation 
Support new functionality (Contact Imports API)
https://help.mailtrap.io/article/147-contacts and https://api-docs.mailtrap.io/docs/mailtrap-api-docs/b46b1fe35bdf1-import-contacts 
Related to #57 

## Changes

* Added new `Mailtrap::ContactImportsAPI` entity for interactions with `ContactImport` API
   * get
   * `create`     which accepts raw data or import request
* `Mailtrap::ContactImport` response object
* `Mailtrap::ContactsImportRequest` import request builder
* Added new tests
* Added examples


## How to test
```
rspec
```
or set yout api key and account id
```ruby
require 'mailtrap'

# export MAILTRAP_API_KEY='your-api-key'
# export MAILTRAP_ACCOUNT_ID=your-account-id
contact_imports = Mailtrap::ContactImportsAPI.new


# Create a new contact import
contact_import = contact_imports.create(
  [
    {
      email: 'imported@example.com',
      fields: {
        first_name: 'Jane',
      },
      list_ids_included: [list.id],
      list_ids_excluded: []
    }
  ]
)

# Get a contact import by ID
contact_imports.get(contact_import.id)

# Create a new contact import using ContactsImportRequest builder
import_request = Mailtrap::ContactsImportRequest.new

# Add contacts using the builder pattern
import_request
  .upsert(
    email: 'john.doe@example.com',
    fields: { first_name: 'John' }
  )
  .add_to_lists(email: 'john.doe@example.com', list_ids: [list.id])
  .upsert(
    email: 'jane.smith@example.com',
    fields: { first_name: 'Jane' }
  )
  .add_to_lists(email: 'jane.smith@example.com', list_ids: [list.id])
  .remove_from_lists(email: 'jane.smith@example.com', list_ids: [])


contact_imports.create(import_request)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing contacts via a new contact import API, including the ability to create and retrieve contact imports.
  * Introduced a new data structure to represent contact import status and counts.
* **Documentation**
  * Updated example script to demonstrate contact import functionality.
* **Tests**
  * Added tests covering successful and error scenarios for contact import operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->