### PR TITLE
Set all mail attributes including template

### DIFF
--- a/lib/mailtrap/mail.rb
+++ b/lib/mailtrap/mail.rb
@@ -189,19 +189,21 @@ module Mailtrap
       # Builds a mail object from Mail::Message
       # @param message [Mail::Message]
       # @return [Mailtrap::Mail::Base]
-      def from_message(message) # rubocop:disable Metrics/AbcSize
+      def from_message(message)
         Mailtrap::Mail::Base.new(
-          from: prepare_addresses(address_list(message['from'])&.addresses).first,
-          to: prepare_addresses(address_list(message['to'])&.addresses),
-          cc: prepare_addresses(address_list(message['cc'])&.addresses),
-          bcc: prepare_addresses(address_list(message['bcc'])&.addresses),
+          from: prepare_addresses(message['from']).first,
+          to: prepare_addresses(message['to']),
+          cc: prepare_addresses(message['cc']),
+          bcc: prepare_addresses(message['bcc']),
           subject: message.subject,
           text: prepare_text_part(message),
           html: prepare_html_part(message),
           headers: prepare_headers(message),
           attachments: prepare_attachments(message.attachments),
           category: message['category']&.unparsed_value,
-          custom_variables: message['custom_variables']&.unparsed_value
+          custom_variables: message['custom_variables']&.unparsed_value,
+          template_uuid: message['template_uuid']&.unparsed_value,
+          template_variables: message['template_variables']&.unparsed_value
         )
       end
 
@@ -219,8 +221,9 @@ module Mailtrap
         header.respond_to?(:element) ? header.element : header.address_list
       end
 
-      # @param addresses [Array<Mail::Address>, nil]
-      def prepare_addresses(addresses)
+      # @param header [Mail::Field, nil]
+      def prepare_addresses(header)
+        addresses = address_list(header)&.addresses
         Array(addresses).map { |address| prepare_address(address) }
       end
 

--- a/spec/mailtrap/mail_spec.rb
+++ b/spec/mailtrap/mail_spec.rb
@@ -143,6 +143,18 @@ RSpec.describe Mailtrap::Mail do
       its(:from) { is_expected.to be_nil }
     end
 
+    context 'when template is set' do
+      let(:message_params) do
+        super().merge(
+          template_uuid: 'c0746b78-f422-46ce-bce5-6f52ad5aab7f',
+          template_variables: { first_name: 'John' }
+        )
+      end
+
+      its(:template_uuid) { is_expected.to eq('c0746b78-f422-46ce-bce5-6f52ad5aab7f') }
+      its(:template_variables) { is_expected.to eq('first_name' => 'John') }
+    end
+
     %i[from to cc bcc].each do |header|
       context "when '#{header}' is invalid" do
         let(:message_params) { super().merge(header => 'invalid email@example.com') }


### PR DESCRIPTION
## Motivation

Provide a possibility to use templates from action mailer.

Is it a right abstraction?

## Changes

- Set `template_uuid` and `template_variables` from message

## How to test

- [ ] Send a message with action mailer
- [ ] Send a message with action mailer specifying template_uiid

## Images and GIFs

N/A